### PR TITLE
[fix](build) Exclude javax.resource:connector from BDB JE dependency

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -950,6 +950,15 @@ under the License.
                         <groupId>org.checkerframework</groupId>
                         <artifactId>checker</artifactId>
                     </exclusion>
+                    <!-- BDB JE only references javax.resource in its optional JCA resource
+                         adapter (com.sleepycat.je.jca.ra), which embedded FE never uses.
+                         javax.resource:connector:1.0 has no jar in Maven Central (only a pom)
+                         and its historical host (repo.grails.org) is unreliable, so pulling it
+                         breaks the build in many environments. Exclude it. -->
+                    <exclusion>
+                        <groupId>javax.resource</groupId>
+                        <artifactId>connector</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 


### PR DESCRIPTION
## What

Exclude `javax.resource:connector` from the `org.apache.doris:je` dependency in `fe/pom.xml`.

## Why

`org.apache.doris:je` transitively pulls in `javax.resource:connector:1.0`, whose **jar was never published to Maven Central** (only the `.pom` is there), and whose historical host (`repo.grails.org`) is frequently unreachable. The FE build then fails:

```
Could not find artifact javax.resource:connector:jar:1.0 in central (...)
Could not transfer artifact javax.resource:connector:jar:1.0 from/to Grails Core
  (https://repo.grails.org/grails/core/): status code: 403, reason phrase: Forbidden
```

BDB JE only references `javax.resource` in its optional JCA resource adapter (`com.sleepycat.je.jca.ra`), which the embedded FE never uses — so the artifact is needed neither at compile nor at runtime.

## How

Add a `<exclusion>` for `javax.resource:connector` to the existing `je` `<exclusions>` block (next to the current `ant` / `checker` exclusions).

## Testing

Full `sh build.sh --fe` reaches and completes `fe-core` compilation (4681 sources) and `BUILD SUCCESS` without the connector jar present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)